### PR TITLE
Add mp3 audio codec playback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ flv.js is written in [ECMAScript 6][], transpiled into ECMAScript 5 by [Babel Co
 [Browserify]: http://browserify.org/
 
 ## Features
-- FLV container with H.264 + AAC codec playback
+- FLV container with H.264 + AAC / MP3 codec playback
 - Multipart segmented video playback
 - HTTP FLV low latency live stream playback
 - FLV over WebSocket live stream playback
@@ -60,6 +60,10 @@ See [cors.md](docs/cors.md) for more details.
     }
 </script>
 ```
+
+## Limitations
+- MP3 audio codec is currently not working on IE11 / Edge
+- HTTP FLV live stream is not currently working on all browsers, see [livestream.md](docs/livestream.md)
 
 ## Multipart playback
 You only have to provide a playlist for `MediaDataSource`. See [multipart.md](docs/multipart.md)

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -507,7 +507,7 @@ class FLVDemuxer {
                     this._onMediaInfo(mi);
                 }
             } else if (aacData.packetType === 1) {  // AAC raw frame data
-                let dts = tagTimestamp;
+                let dts = this._timestampBase + tagTimestamp;
                 let aacSample = {unit: aacData.data, dts: dts, pts: dts};
                 track.samples.push(aacSample);
                 track.length += aacData.data.length;
@@ -550,7 +550,7 @@ class FLVDemuxer {
                 if (data == undefined) {
                     return;
                 }
-                let dts = tagTimestamp;
+                let dts = this._timestampBase + tagTimestamp;
                 let mp3Sample = {unit: data, dts: dts, pts: dts};
                 track.samples.push(mp3Sample);
                 track.length += data.length;

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -84,6 +84,21 @@ class FLVDemuxer {
             fps_den: 1000
         };
 
+        this._flvSoundRateTable = [5500, 11025, 22050, 44100, 48000];
+
+        this._mpegSamplingRates = [
+            96000, 88200, 64000, 48000, 44100, 32000,
+            24000, 22050, 16000, 12000, 11025, 8000, 7350
+        ];
+
+        this._mpegAudioV10SampleRateTable = [44100, 48000, 32000, 0];
+        this._mpegAudioV20SampleRateTable = [22050, 24000, 16000, 0];
+        this._mpegAudioV25SampleRateTable = [11025, 12000, 8000,  0];
+
+        this._mpegAudioL1BitRateTable = [0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, -1];
+        this._mpegAudioL2BitRateTable = [0, 32, 48, 56,  64,  80,  96, 112, 128, 160, 192, 224, 256, 320, 384, -1];
+        this._mpegAudioL3BitRateTable = [0, 32, 40, 48,  56,  64,  80,  96, 112, 128, 160, 192, 224, 256, 320, -1];
+
         this._videoTrack = {type: 'video', id: 1, sequenceNumber: 0, samples: [], length: 0};
         this._audioTrack = {type: 'audio', id: 2, sequenceNumber: 0, samples: [], length: 0};
 
@@ -407,102 +422,139 @@ class FLVDemuxer {
             return;
         }
 
+        let le = this._littleEndian;
+        let v = new DataView(arrayBuffer, dataOffset, dataSize);
+
+        let soundSpec = v.getUint8(0);
+
+        let soundFormat = soundSpec >>> 4;
+        if (soundFormat !== 2 && soundFormat !== 10) {  // MP3 or AAC
+            this._onError(DemuxErrors.CODEC_UNSUPPORTED, 'Flv: Unsupported audio codec idx: ' + soundFormat);
+            return;
+        }
+
+        let soundRate = 0;
+        let soundRateIndex = (soundSpec & 12) >>> 2;
+        if (soundRateIndex >= 0 && soundRateIndex <= 4) {
+            soundRate = this._flvSoundRateTable[soundRateIndex];
+        } else {
+            this._onError(DemuxErrors.FORMAT_ERROR, 'Flv: Invalid audio sample rate idx: ' + soundRateIndex);
+            return;
+        }
+
+        let soundSize = (soundSpec & 2) >>> 1;  // unused
+        let soundType = (soundSpec & 1);
+
+
         let meta = this._audioMetadata;
         let track = this._audioTrack;
 
-        if (!meta || !meta.codec) {
+        if (!meta) {
             // initial metadata
             meta = this._audioMetadata = {};
             meta.type = 'audio';
             meta.id = track.id;
             meta.timescale = this._timescale;
             meta.duration = this._duration;
-
-            let le = this._littleEndian;
-            let v = new DataView(arrayBuffer, dataOffset, dataSize);
-
-            let soundSpec = v.getUint8(0);
-
-            let soundFormat = soundSpec >>> 4;
-            if (soundFormat !== 10) {  // AAC
-                // TODO: support MP3 audio codec
-                this._onError(DemuxErrors.CODEC_UNSUPPORTED, 'Flv: Unsupported audio codec idx: ' + soundFormat);
-                return;
-            }
-
-            let soundRate = 0;
-            let soundRateIndex = (soundSpec & 12) >>> 2;
-
-            let soundRateTable = [5500, 11025, 22050, 44100, 48000];
-
-            if (soundRateIndex < soundRateTable.length) {
-                soundRate = soundRateTable[soundRateIndex];
-            } else {
-                this._onError(DemuxErrors.FORMAT_ERROR, 'Flv: Invalid audio sample rate idx: ' + soundRateIndex);
-                return;
-            }
-
-            let soundSize = (soundSpec & 2) >>> 1;  // unused
-            let soundType = (soundSpec & 1);
-
             meta.audioSampleRate = soundRate;
             meta.channelCount = (soundType === 0 ? 1 : 2);
-            meta.refSampleDuration = Math.floor(1024 / meta.audioSampleRate * meta.timescale);
-            meta.codec = 'mp4a.40.5';
         }
 
-        let aacData = this._parseAACAudioData(arrayBuffer, dataOffset + 1, dataSize - 1);
-        if (aacData == undefined) {
-            return;
-        }
-
-        if (aacData.packetType === 0) {  // AAC sequence header (AudioSpecificConfig)
-            if (meta.config) {
-                Log.w(this.TAG, 'Found another AudioSpecificConfig!');
+        if (soundFormat === 10) {  // AAC
+            let aacData = this._parseAACAudioData(arrayBuffer, dataOffset + 1, dataSize - 1);
+            if (aacData == undefined) {
+                return;
             }
-            let misc = aacData.data;
-            meta.audioSampleRate = misc.samplingRate;
-            meta.channelCount = misc.channelCount;
-            meta.codec = misc.codec;
-            meta.config = misc.config;
-            // The decode result of an aac sample is 1024 PCM samples
-            meta.refSampleDuration = Math.floor(1024 / meta.audioSampleRate * meta.timescale);
-            Log.v(this.TAG, 'Parsed AudioSpecificConfig');
 
-            if (this._isInitialMetadataDispatched()) {
-                // Non-initial metadata, force dispatch (or flush) parsed frames to remuxer
-                if (this._dispatch && (this._audioTrack.length || this._videoTrack.length)) {
-                    this._onDataAvailable(this._audioTrack, this._videoTrack);
+            if (aacData.packetType === 0) {  // AAC sequence header (AudioSpecificConfig)
+                if (meta.config) {
+                    Log.w(this.TAG, 'Found another AudioSpecificConfig!');
                 }
+                let misc = aacData.data;
+                meta.audioSampleRate = misc.samplingRate;
+                meta.channelCount = misc.channelCount;
+                meta.codec = misc.codec;
+                meta.config = misc.config;
+                meta.esdsSubType = 0x40;  // Audio 14496-3 AAC Main
+                // The decode result of an aac sample is 1024 PCM samples
+                meta.refSampleDuration = Math.floor(1024 / meta.audioSampleRate * meta.timescale);
+                Log.v(this.TAG, 'Parsed AudioSpecificConfig');
+
+                if (this._isInitialMetadataDispatched()) {
+                    // Non-initial metadata, force dispatch (or flush) parsed frames to remuxer
+                    if (this._dispatch && (this._audioTrack.length || this._videoTrack.length)) {
+                        this._onDataAvailable(this._audioTrack, this._videoTrack);
+                    }
+                } else {
+                    this._audioInitialMetadataDispatched = true;
+                }
+                // then notify new metadata
+                this._dispatch = false;
+                this._onTrackMetadata('audio', meta);
+
+                let mi = this._mediaInfo;
+                mi.audioCodec = 'mp4a.40.' + misc.originalAudioObjectType;
+                mi.audioSampleRate = meta.audioSampleRate;
+                mi.audioChannelCount = meta.channelCount;
+                if (mi.hasVideo) {
+                    if (mi.videoCodec != null) {
+                        mi.mimeType = 'video/x-flv; codecs="' + mi.videoCodec + ',' + mi.audioCodec + '"';
+                    }
+                } else {
+                    mi.mimeType = 'video/x-flv; codecs="' + mi.audioCodec + '"';
+                }
+                if (mi.isComplete()) {
+                    this._onMediaInfo(mi);
+                }
+            } else if (aacData.packetType === 1) {  // AAC raw frame data
+                let dts = tagTimestamp;
+                let aacSample = {unit: aacData.data, dts: dts, pts: dts};
+                track.samples.push(aacSample);
+                track.length += aacData.data.length;
             } else {
+                Log.e(this.TAG, `Flv: Unsupported AAC data type ${aacData.packetType}`);
+            }
+        } else if (soundFormat === 2) {  // MP3
+            if (!meta.codec) {
+                let misc = this._parseMP3AudioData(arrayBuffer, dataOffset + 1, dataSize - 1, true);
+                if (misc == undefined) {
+                    return;
+                }
+                meta.audioSampleRate = misc.samplingRate;
+                meta.channelConfig = misc.channelCount;
+                meta.codec = misc.codec;
+                meta.esdsSubType = 0x6B;
+                meta.refSampleDuration = Math.floor(1152 / meta.audioSampleRate * meta.timescale);
+                Log.v(this.TAG, 'Parsed MP3 frame header');
+
                 this._audioInitialMetadataDispatched = true;
-            }
-            // then notify new metadata
-            this._dispatch = false;
-            this._onTrackMetadata('audio', meta);
+                this._onTrackMetadata('audio', meta);
 
-            let mi = this._mediaInfo;
-            mi.audioCodec = 'mp4a.40.' + misc.originalAudioObjectType;
-            mi.audioSampleRate = meta.audioSampleRate;
-            mi.audioChannelCount = meta.channelCount;
-            if (mi.hasVideo) {
-                if (mi.videoCodec != null) {
-                    mi.mimeType = 'video/x-flv; codecs="' + mi.videoCodec + ',' + mi.audioCodec + '"';
+                let mi = this._mediaInfo;
+                mi.audioCodec = meta.codec;
+                mi.audioSampleRate = meta.audioSampleRate;
+                mi.audioChannelCount = meta.channelCount;
+                mi.audioBitrate = misc.bitRate;
+                if (mi.hasVideo) {
+                    if (mi.videoCodec != null) {
+                        mi.mimeType = 'video/x-flv; codecs="' + mi.videoCodec + ',' + mi.audioCodec + '"';
+                    }
+                } else {
+                    mi.mimeType = 'video/x-flv; codecs="' + mi.audioCodec + '"';
+                }
+                if (mi.isComplete()) {
+                    this._onMediaInfo(mi);
                 }
             } else {
-                mi.mimeType = 'video/x-flv; codecs="' + mi.audioCodec + '"';
+                let data = this._parseMP3AudioData(arrayBuffer, dataOffset + 1, dataSize - 1, false);
+                if (data == undefined) {
+                    return;
+                }
+                let dts = tagTimestamp;
+                let mp3Sample = {unit: data, dts: dts, pts: dts};
+                track.samples.push(mp3Sample);
+                track.length += data.length;
             }
-            if (mi.isComplete()) {
-                this._onMediaInfo(mi);
-            }
-            return;
-        } else if (aacData.packetType === 1) {  // AAC raw frame data
-            let dts = this._timestampBase + tagTimestamp;
-            let aacSample = {unit: aacData.data, dts: dts, pts: dts};
-            track.samples.push(aacSample);
-            track.length += aacData.data.length;
-        } else {
-            Log.e(this.TAG, `Flv: Unsupported AAC data type ${aacData.packetType}`);
         }
     }
 
@@ -530,11 +582,6 @@ class FLVDemuxer {
         let array = new Uint8Array(arrayBuffer, dataOffset, dataSize);
         let config = null;
 
-        let mpegSamplingRates = [
-            96000, 88200, 64000, 48000, 44100, 32000,
-            24000, 22050, 16000, 12000, 11025, 8000, 7350
-        ];
-
         /* Audio Object Type:
            0: Null
            1: AAC Main
@@ -555,12 +602,12 @@ class FLVDemuxer {
         audioObjectType = originalAudioObjectType = array[0] >>> 3;
         // 4 bits
         samplingIndex = ((array[0] & 0x07) << 1) | (array[1] >>> 7);
-        if (samplingIndex < 0 || samplingIndex >= mpegSamplingRates.length) {
+        if (samplingIndex < 0 || samplingIndex >= this._mpegSamplingRates.length) {
             this._onError(DemuxErrors.FORMAT_ERROR, 'Flv: AAC invalid sampling frequency index!');
             return;
         }
 
-        let samplingFrequence = mpegSamplingRates[samplingIndex];
+        let samplingFrequence = this._mpegSamplingRates[samplingIndex];
 
         // 4 bits
         let channelConfig = (array[1] & 0x78) >>> 3;
@@ -630,6 +677,79 @@ class FLVDemuxer {
             codec: 'mp4a.40.' + audioObjectType,
             originalAudioObjectType: originalAudioObjectType
         };
+    }
+
+    _parseMP3AudioData(arrayBuffer, dataOffset, dataSize, requestHeader) {
+        if (dataSize < 4) {
+            Log.w(this.TAG, 'Flv: Invalid MP3 packet, header missing!');
+            return;
+        }
+
+        let le = this._littleEndian;
+        let array = new Uint8Array(arrayBuffer, dataOffset, dataSize);
+        let result = null;
+
+        if (requestHeader) {
+            if (array[0] !== 0xFF) {
+                return;
+            }
+            let ver = (array[1] >>> 3) & 0x03;
+            let layer = (array[1] & 0x06) >> 1;
+
+            let bitrate_index = (array[2] & 0xF0) >>> 4;
+            let sampling_freq_index = (array[2] & 0x0C) >>> 2;
+
+            let channel_mode = (array[3] >>> 6) & 0x03;
+            let channel_count = channel_mode !== 3 ? 2 : 1;
+
+            let sample_rate = 0;
+            let bit_rate = 0;
+            let object_type = 34;  // Layer-3, listed in MPEG-4 Audio Object Types
+
+            switch (ver) {
+                case 0:  // MPEG 2.5
+                    sample_rate = this._mpegAudioV25SampleRateTable[sampling_freq_index];
+                    break;
+                case 2:  // MPEG 2
+                    sample_rate = this._mpegAudioV20SampleRateTable[sampling_freq_index];
+                    break;
+                case 3:  // MPEG 1
+                    sample_rate = this._mpegAudioV10SampleRateTable[sampling_freq_index];
+                    break;
+            }
+
+            switch (layer) {
+                case 1:  // Layer 3
+                    object_type = 34;
+                    if (bitrate_index < this._mpegAudioL3BitRateTable.length) {
+                        bit_rate = this._mpegAudioL3BitRateTable[bitrate_index];
+                    }
+                    break;
+                case 2:  // Layer 2
+                    object_type = 33;
+                    if (bitrate_index < this._mpegAudioL2BitRateTable.length) {
+                        bit_rate = this._mpegAudioL2BitRateTable[bitrate_index];
+                    }
+                    break;
+                case 3:  // Layer 1
+                    object_type = 32;
+                    if (bitrate_index < this._mpegAudioL1BitRateTable.length) {
+                        bit_rate = this._mpegAudioL1BitRateTable[bitrate_index];
+                    }
+                    break;
+            }
+
+            result = {
+                bitRate: bit_rate,
+                samplingRate: sample_rate,
+                channelCount: channel_count,
+                codec: 'mp4a.40.' + object_type
+            };
+        } else {
+            result = array;
+        }
+
+        return result;
     }
 
     _parseVideoData(arrayBuffer, dataOffset, dataSize, tagTimestamp, tagPosition) {

--- a/src/remux/mp4-generator.js
+++ b/src/remux/mp4-generator.js
@@ -345,7 +345,8 @@ class MP4 {
     }
 
     static esds(meta) {
-        let config = meta.config;
+        let esdsSubType = meta.esdsSubType;
+        let config = meta.config || [];
         let configSize = config.length;
         let data = new Uint8Array([
             0x00, 0x00, 0x00, 0x00,  // version 0 + flags
@@ -357,7 +358,7 @@ class MP4 {
 
             0x04,                    // descriptor_type
             0x0F + configSize,       // length
-            0x40,                    // codec: mpeg4_audio
+            esdsSubType,             // codec
             0x15,                    // stream_type: Audio
             0x00, 0x00, 0x00,        // buffer_size
             0x00, 0x00, 0x00, 0x00,  // maxBitrate

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -58,6 +58,9 @@ class MP4Remuxer {
         // Workaround for IE11/Edge: Fill silent aac frame after keyframe-seeking
         // Make audio beginDts equals with video beginDts, in order to fix seek freeze
         this._fillSilentAfterSeek = (Browser.msedge || Browser.msie);
+
+        // While only FireFox supports 'audio/mp4, codecs="mp3"', use 'audio/mpeg' for chrome, safari, ...
+        this._mp3UseMpegAudio = !Browser.firefox;
     }
 
     destroy() {
@@ -134,9 +137,20 @@ class MP4Remuxer {
     _onTrackMetadataReceived(type, metadata) {
         let metabox = null;
 
+        let container = 'mp4';
+        let codec = metadata.codec;
+
         if (type === 'audio') {
             this._audioMeta = metadata;
-            metabox = MP4.generateInitSegment(metadata);
+            if (metadata.codec === 'mp3' && this._mp3UseMpegAudio) {
+                // 'audio/mpeg' for MP3 audio track
+                container = 'mpeg';
+                codec = '';
+                metabox = new Uint8Array();
+            } else {
+                // 'audio/mp4, codecs="codec"'
+                metabox = MP4.generateInitSegment(metadata);
+            }
         } else if (type === 'video') {
             this._videoMeta = metadata;
             metabox = MP4.generateInitSegment(metadata);
@@ -151,8 +165,8 @@ class MP4Remuxer {
         this._onInitSegment(type, {
             type: type,
             data: metabox.buffer,
-            codec: metadata.codec,
-            container: `${type}/mp4`
+            codec: codec,
+            container: `${type}/${container}`
         });
     }
 
@@ -178,6 +192,9 @@ class MP4Remuxer {
         let dtsCorrection = undefined;
         let firstDts = -1, lastDts = -1, lastPts = -1;
 
+        let mpegRawTrack = this._audioMeta.codec === 'mp3' && this._mp3UseMpegAudio;
+        let firstSegmentAfterSeek = this._dtsBaseInited && this._audioNextDts === undefined;
+
         let remuxSilentFrame = false;
         let silentFrameDuration = -1;
 
@@ -185,16 +202,29 @@ class MP4Remuxer {
             return;
         }
 
-        let bytes = 8 + track.length;
-        let mdatbox = new Uint8Array(bytes);
-        mdatbox[0] = (bytes >>> 24) & 0xFF;
-        mdatbox[1] = (bytes >>> 16) & 0xFF;
-        mdatbox[2] = (bytes >>>  8) & 0xFF;
-        mdatbox[3] = (bytes) & 0xFF;
+        let bytes = 0;
+        let offset = 0;
+        let mdatbox = null;
 
-        mdatbox.set(MP4.types.mdat, 4);
+        if (mpegRawTrack) {
+            // allocate for raw mpeg buffer
+            bytes = track.length;
+            offset = 0;
+            mdatbox = new Uint8Array(bytes);
+        } else {
+            // allocate for fmp4 mdat box
+            bytes = 8 + track.length;
+            offset = 8;  // size + type
+            mdatbox = new Uint8Array(bytes);
+            // size field
+            mdatbox[0] = (bytes >>> 24) & 0xFF;
+            mdatbox[1] = (bytes >>> 16) & 0xFF;
+            mdatbox[2] = (bytes >>>  8) & 0xFF;
+            mdatbox[3] = (bytes) & 0xFF;
+            // type field (fourCC)
+            mdatbox.set(MP4.types.mdat, 4);
+        }
 
-        let offset = 8;  // size + type
         let mp4Samples = [];
 
         while (samples.length) {
@@ -207,7 +237,9 @@ class MP4Remuxer {
                     if (this._audioSegmentInfoList.isEmpty()) {
                         dtsCorrection = 0;
                         if (this._fillSilentAfterSeek && !this._videoSegmentInfoList.isEmpty()) {
-                            remuxSilentFrame = true;
+                            if (this._audioMeta.codec !== 'mp3') {
+                                remuxSilentFrame = true;
+                            }
                         }
                     } else {
                         let lastSample = this._audioSegmentInfoList.getLastSampleBefore(originalDts);
@@ -330,16 +362,33 @@ class MP4Remuxer {
         track.samples = mp4Samples;
         track.sequenceNumber++;
 
-        let moofbox = MP4.moof(track, firstDts);
+        let moofbox = null;
+
+        if (mpegRawTrack) {
+            // Generate empty buffer, because useless for raw mpeg
+            moofbox = new Uint8Array();
+        } else {
+            // Generate moof for fmp4 segment
+            moofbox = MP4.moof(track, firstDts);
+        }
+
         track.samples = [];
         track.length = 0;
 
-        this._onMediaSegment('audio', {
+        let segment = {
             type: 'audio',
             data: this._mergeBoxes(moofbox, mdatbox).buffer,
             sampleCount: mp4Samples.length,
             info: info
-        });
+        };
+
+        if (mpegRawTrack && firstSegmentAfterSeek) {
+            // For MPEG audio stream in MSE, if seeking occurred, before appending new buffer
+            // We need explicitly set timestampOffset to the desired point in timeline for mpeg SourceBuffer.
+            segment.timestampOffset = firstDts;
+        }
+
+        this._onMediaSegment('audio', segment);
     }
 
     _generateSilentAudio(dts, frameDuration) {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -166,7 +166,8 @@ class MP4Remuxer {
             type: type,
             data: metabox.buffer,
             codec: codec,
-            container: `${type}/${container}`
+            container: `${type}/${container}`,
+            mediaDuration: metadata.duration  // in timescale 1000 (milliseconds)
         });
     }
 

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -33,7 +33,7 @@ function detect() {
         /(opera)(?:.*version|)[ \/]([\w.]+)/.exec(ua) ||
         /(msie) ([\w.]+)/.exec(ua) ||
         ua.indexOf('trident') >= 0 && /(rv)(?::| )([\w.]+)/.exec(ua) ||
-        ua.indexOf('compatible') < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua) ||
+        ua.indexOf('compatible') < 0 && /(firefox)[ \/]([\w.]+)/.exec(ua) ||
         [];
 
     let platform_match = /(ipad)/.exec(ua) ||


### PR DESCRIPTION
Branch [dev-mp3-audio-support](https://github.com/Bilibili/flv.js/tree/dev-mp3-audio-support) has successfully implemented mp3 audio playback.
Now, flv.js supports FLV video with mp3 audio codec. 

For FireFox, create SourceBuffer with `audio/mp4,codecs="mp3"` and wrap mp3 packets within fmp4 container;

For Chrome, Safari and other browsers, create SourceBuffer with `audio/mpeg` and write mp3 packets into mpeg raw segments;

For IE11 / Edge, there's still a bug which preventing mp3 audio playback works:
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8972303/

Inspired from hls.js's implementation.

Test and feedback is welcome.