### PR TITLE
fix audio async 修复某些情况下音画不同步问题

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -538,7 +538,7 @@ class MP4Remuxer {
             mp4Samples.push(mp4Sample);
         }
         let latest = mp4Samples[mp4Samples.length - 1];
-        lastDts = latest.dts + latest.duration;
+        lastDts = latest.originalDts + latest.duration;
         lastPts = latest.pts + latest.duration;
         this._videoNextDts = lastDts;
 


### PR DESCRIPTION
在播放直播流时，dtsCorrection可能随着时间逐渐增大，最终造成音画不同步。
做如下修改之后恢复正常。