### PR TITLE
fix live streaming memory problem 修复直播情况下内存一直增长问题

### DIFF
--- a/src/player/flv-player.js
+++ b/src/player/flv-player.js
@@ -136,7 +136,7 @@ class FlvPlayer {
         mediaElement.addEventListener('stalled', this.e.onvStalled);
         mediaElement.addEventListener('progress', this.e.onvProgress);
 
-        this._msectl = new MSEController();
+        this._msectl = new MSEController(this._config);
 
         this._msectl.on(MSEEvents.UPDATE_END, this._onmseUpdateEnd.bind(this));
         this._msectl.on(MSEEvents.BUFFER_FULL, this._onmseBufferFull.bind(this));


### PR DESCRIPTION
直播场景下，因为流是一直不断的，放几个小时都有可能。
前面的buffer对直播流来说没有什么作用，一直不释放会白白占用内存，我测试最多涨到过700M，看了几个小时。
因此，我在内部添加了一个逻辑，在直播场景下，每隔10s进行检查，buffer大于60s，就将前面的部分buffer remove掉。
观测结果是内存一直维持在150M左右的水平，没有再进行增长。