### PR TITLE
Added support of metadata events

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -189,6 +189,7 @@ A series of constants that can be used with `Player.on()` / `Player.off()`. They
 | LOADING_COMPLETE    | The input MediaDataSource has been completely buffered to end |
 | RECOVERED_EARLY_EOF | An unexpected network EOF occurred during buffering but automatically recovered |
 | MEDIA_INFO          | Provides technical information of the media like video/audio codec, bitrate, etc. |
+| METADATA_ARRIVED    | Provides metadata which FLV file(stream) can contain with an "onMetaData" marker.  |
 | STATISTICS_INFO     | Provides playback statistics information like dropped frames, current speed, etc. |
 
 ### flvjs.ErrorTypes

--- a/src/core/transmuxer.js
+++ b/src/core/transmuxer.js
@@ -60,6 +60,7 @@ class Transmuxer {
             ctl.on(TransmuxingEvents.LOADING_COMPLETE, this._onLoadingComplete.bind(this));
             ctl.on(TransmuxingEvents.RECOVERED_EARLY_EOF, this._onRecoveredEarlyEof.bind(this));
             ctl.on(TransmuxingEvents.MEDIA_INFO, this._onMediaInfo.bind(this));
+            ctl.on(TransmuxingEvents.METADATA_ARRIVED, this._onMetadataArrived.bind(this));
             ctl.on(TransmuxingEvents.STATISTICS_INFO, this._onStatisticsInfo.bind(this));
             ctl.on(TransmuxingEvents.RECOMMEND_SEEKPOINT, this._onRecommendSeekpoint.bind(this));
         }
@@ -164,6 +165,12 @@ class Transmuxer {
         });
     }
 
+    _onMetadataArrived(metadata) {
+        Promise.resolve().then(() => {
+            this._emitter.emit(TransmuxingEvents.METADATA_ARRIVED, metadata);
+        });
+    }
+
     _onStatisticsInfo(statisticsInfo) {
         Promise.resolve().then(() => {
             this._emitter.emit(TransmuxingEvents.STATISTICS_INFO, statisticsInfo);
@@ -218,6 +225,7 @@ class Transmuxer {
                 Object.setPrototypeOf(data, MediaInfo.prototype);
                 this._emitter.emit(message.msg, data);
                 break;
+            case TransmuxingEvents.METADATA_ARRIVED:
             case TransmuxingEvents.STATISTICS_INFO:
                 this._emitter.emit(message.msg, data);
                 break;

--- a/src/core/transmuxing-controller.js
+++ b/src/core/transmuxing-controller.js
@@ -265,6 +265,7 @@ class TransmuxingController {
 
             this._demuxer.onError = this._onDemuxException.bind(this);
             this._demuxer.onMediaInfo = this._onMediaInfo.bind(this);
+            this._demuxer.onMetadataArrived = this._onMetadataArrived.bind(this);
 
             this._remuxer.bindDataSource(this._demuxer
                          .bindDataSource(this._ioctl
@@ -312,6 +313,10 @@ class TransmuxingController {
                 this.seek(target);
             });
         }
+    }
+
+    _onMetadataArrived(metadata) {
+        this._emitter.emit(TransmuxingEvents.METADATA_ARRIVED, metadata);
     }
 
     _onIOSeeked() {

--- a/src/core/transmuxing-events.js
+++ b/src/core/transmuxing-events.js
@@ -24,6 +24,7 @@ const TransmuxingEvents = {
     LOADING_COMPLETE: 'loading_complete',
     RECOVERED_EARLY_EOF: 'recovered_early_eof',
     MEDIA_INFO: 'media_info',
+    METADATA_ARRIVED: 'metadata_arrived',
     STATISTICS_INFO: 'statistics_info',
     RECOMMEND_SEEKPOINT: 'recommend_seekpoint'
 };

--- a/src/core/transmuxing-worker.js
+++ b/src/core/transmuxing-worker.js
@@ -54,6 +54,7 @@ let TransmuxingWorker = function (self) {
                 controller.on(TransmuxingEvents.LOADING_COMPLETE, onLoadingComplete.bind(this));
                 controller.on(TransmuxingEvents.RECOVERED_EARLY_EOF, onRecoveredEarlyEof.bind(this));
                 controller.on(TransmuxingEvents.MEDIA_INFO, onMediaInfo.bind(this));
+                controller.on(TransmuxingEvents.METADATA_ARRIVED, onMetadataArrived.bind(this));
                 controller.on(TransmuxingEvents.STATISTICS_INFO, onStatisticsInfo.bind(this));
                 controller.on(TransmuxingEvents.RECOMMEND_SEEKPOINT, onRecommendSeekpoint.bind(this));
                 break;
@@ -133,6 +134,14 @@ let TransmuxingWorker = function (self) {
         let obj = {
             msg: TransmuxingEvents.MEDIA_INFO,
             data: mediaInfo
+        };
+        self.postMessage(obj);
+    }
+
+    function onMetadataArrived(metadata) {
+        let obj = {
+            msg: TransmuxingEvents.METADATA_ARRIVED,
+            data: metadata
         };
         self.postMessage(obj);
     }

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -52,6 +52,7 @@ class FLVDemuxer {
 
         this._onError = null;
         this._onMediaInfo = null;
+        this._onMetadataArrived = null;
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
 
@@ -122,6 +123,7 @@ class FLVDemuxer {
 
         this._onError = null;
         this._onMediaInfo = null;
+        this._onMetadataArrived = null;
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
     }
@@ -173,6 +175,14 @@ class FLVDemuxer {
 
     set onMediaInfo(callback) {
         this._onMediaInfo = callback;
+    }
+
+    get onMetadataArrived() {
+        return this._onMetadataArrived;
+    }
+
+    set onMetadataArrived(callback) {
+        this._onMetadataArrived = callback;
     }
 
     // prototype: function(type: number, info: string): void
@@ -414,6 +424,9 @@ class FLVDemuxer {
             this._dispatch = false;
             this._mediaInfo.metadata = onMetaData;
             Log.v(this.TAG, 'Parsed onMetaData');
+            if(this._onMetadataArrived) {
+                this._onMetadataArrived(Object.assign({}, onMetaData));
+            }
             if (this._mediaInfo.isComplete()) {
                 this._onMediaInfo(this._mediaInfo);
             }

--- a/src/player/flv-player.js
+++ b/src/player/flv-player.js
@@ -242,6 +242,9 @@ class FlvPlayer {
             this._mediaInfo = mediaInfo;
             this._emitter.emit(PlayerEvents.MEDIA_INFO, Object.assign({}, mediaInfo));
         });
+        this._transmuxer.on(TransmuxingEvents.METADATA_ARRIVED, (metadata) => {
+            this._emitter.emit(PlayerEvents.METADATA_ARRIVED, metadata);
+        });
         this._transmuxer.on(TransmuxingEvents.STATISTICS_INFO, (statInfo) => {
             this._statisticsInfo = this._fillStatisticsInfo(statInfo);
             this._emitter.emit(PlayerEvents.STATISTICS_INFO, Object.assign({}, this._statisticsInfo));

--- a/src/player/player-events.js
+++ b/src/player/player-events.js
@@ -21,6 +21,7 @@ const PlayerEvents = {
     LOADING_COMPLETE: 'loading_complete',
     RECOVERED_EARLY_EOF: 'recovered_early_eof',
     MEDIA_INFO: 'media_info',
+    METADATA_ARRIVED: 'metadata_arrived',
     STATISTICS_INFO: 'statistics_info'
 };
 


### PR DESCRIPTION
Sometimes we can't rely on MEDIA_INFO events because first metadata can be overwritten next one. For example if we have tags: script data, video, video, script data, audio - the second part will rewrite the first. I propose to divide the receipt of events with METADATA_ARRIVED name to handle metadata without waiting MEDIA_INFO.
