### PR TITLE
Wrapped `ms.removeSourceBuffer(sb);` in try/catch

### DIFF
--- a/src/core/mse-controller.js
+++ b/src/core/mse-controller.js
@@ -125,7 +125,12 @@ class MSEController {
                 let sb = this._sourceBuffers[type];
                 if (sb) {
                     if (ms.readyState !== 'closed') {
-                        ms.removeSourceBuffer(sb);
+                        // ms edge can throw an error: Unexpected call to method or property access
+                        try {
+                            ms.removeSourceBuffer(sb);
+                        } catch (error) {
+                            Log.e(this.TAG, error.message);
+                        }
                         sb.removeEventListener('error', this.e.onSourceBufferError);
                         sb.removeEventListener('updateend', this.e.onSourceBufferUpdateEnd);
                     }


### PR DESCRIPTION
I caught an error in my videos in MS Edge. It's very strange behaviour for me:

`
> 'removeSourceBuffer' in ms
< true

> typeof ms.removeSourceBuffer
< "function"

> ms.constructor
< function MediaSource () ...

>ms.removeSourceBuffer(sb);
< Error: Unexpected call to method or property access
`

Unfortunately I have no time to go deeper now. This works for me
