### PR TITLE
use a new silent frame insert algorithm for audio remux

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flv.js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "HTML5 FLV Player",
   "main": "./dist/flv.js",
   "module": "./src/flv.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flv.js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "HTML5 FLV Player",
   "main": "./dist/flv.js",
   "module": "./src/flv.js",

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -121,6 +121,7 @@ class MP4Remuxer {
 
     insertDiscontinuity() {
         this._audioNextDts = this._videoNextDts = undefined;
+        this._audioNextRefDts = undefined;
     }
 
     seek(originalDts) {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -412,7 +412,7 @@ class MP4Remuxer {
                             }
                         };
                         silentFrames.push(frame);
-                        mdatBytes += unit.byteLength;
+                        mdatBytes += frame.size;;
 
                     }
 

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -242,8 +242,6 @@ class MP4Remuxer {
         let dtsCorrection = undefined;
         let firstDts = -1, lastDts = -1, lastPts = -1;
         let refSampleDuration = this._audioMeta.refSampleDuration;
-        Log.v(this.TAG, `refSampleDuration: ${refSampleDuration}`);
-
 
         let mpegRawTrack = this._audioMeta.codec === 'mp3' && this._mp3UseMpegAudio;
         let firstSegmentAfterSeek = this._dtsBaseInited && this._audioNextDts === undefined;
@@ -386,7 +384,6 @@ class MP4Remuxer {
 
                     dts = Math.floor(curRefDts);
                     sampleDuration = Math.floor(curRefDts + refSampleDuration) - dts;
-                    curRefDts = curRefDts + refSampleDuration;
 
                     let silentUnit = AAC.getSilentFrame(this._audioMeta.originalCodec, this._audioMeta.channelCount);
                     if (silentUnit == null) {
@@ -398,6 +395,7 @@ class MP4Remuxer {
                     silentFrames = [];
 
                     for (let j = 0; j < frameCount; j++) {
+                        curRefDts = curRefDts + refSampleDuration;
                         let intDts = Math.floor(curRefDts);  // change to integer
                         let intDuration = Math.floor(curRefDts + refSampleDuration) - intDts;
                         let frame = {
@@ -417,7 +415,7 @@ class MP4Remuxer {
                         };
                         silentFrames.push(frame);
                         mdatBytes += unit.byteLength;
-                        curRefDts = curRefDts + refSampleDuration;
+
                     }
 
                     this._audioNextRefDts = curRefDts + refSampleDuration;

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -366,18 +366,18 @@ class MP4Remuxer {
                 dtsCorrection = originalDts - curRefDts;
                 if (dtsCorrection <= -maxAudioFramesDrift * refSampleDuration) {
                     // If we're overlapping by more than maxAudioFramesDrift number of frame, drop this sample
-                    Log.w(this.TAG, `Dropping 1 audio frame (originalDts: ${originalDts} ms ,curRefDts: ${curRefDts} ms)  due to delta: ${delta} ms overlap.`);
+                    Log.w(this.TAG, `Dropping 1 audio frame (originalDts: ${originalDts} ms ,curRefDts: ${curRefDts} ms)  due to dtsCorrection: ${dtsCorrection} ms overlap.`);
                     continue;
                 }
                 else if (dtsCorrection >= maxAudioFramesDrift * refSampleDuration && this._fillAudioTimestampGap && !Browser.safari) {
                     // Silent frame generation, if large timestamp gap detected && config.fixAudioTimestampGap
                     needFillSilentFrames = true;
                     // We need to insert silent frames to fill timestamp gap
-                    let frameCount = Math.floor(delta / refSampleDuration);
+                    let frameCount = Math.floor(dtsCorrection / refSampleDuration);
                     Log.w(this.TAG, 'Large audio timestamp gap detected, may cause AV sync to drift. ' +
                         'Silent frames will be generated to avoid unsync.\n' +
                         `originalDts: ${originalDts} ms, curRefDts: ${curRefDts} ms, ` +
-                        `delta: ${Math.round(delta)} ms, generate: ${frameCount} frames`);
+                        `dtsCorrection: ${Math.round(dtsCorrection)} ms, generate: ${frameCount} frames`);
 
 
                     dts = Math.floor(curRefDts);


### PR DESCRIPTION
the old algorithm cannot cover some common situation, like:
1. audio frame dts does not increase by a standard duration, sometimes it increase for a large duration(more than 1.5 * refSampleDuration), sometimes it increase for a small duration. But the average duration is more or less to refSampleDuration. the old algorithm would insert silent frames which result into video/audio unsync.
2. for network living stream, because of network jitter or frame lost, the encoder would generate the audio frames whose dts is not correct. but if the gap between two adjacent frame is not over 1.5 * refSampleDuration and the accumulate gap would become larger and larger. the old algorithm never insert silent frames for this case.
