### PR TITLE
Added optional additional headers to createPlayer config for FetchStreamLoader

### DIFF
--- a/d.ts/flv.d.ts
+++ b/d.ts/flv.d.ts
@@ -155,7 +155,12 @@ declare namespace FlvJs {
          * @defaultvalue 'no-referrer-when-downgrade' (from docs)
          */
         referrerPolicy?: ReferrerPolicy;
-
+        /**
+         * @desc Indicates additional headers that will be added to request
+         */
+        headers?: {
+            [k: string]: string
+        }
         /**
          * @desc Should implement `BaseLoader` interface
          */

--- a/docs/api.md
+++ b/docs/api.md
@@ -88,6 +88,7 @@ In multipart mode, `duration` `filesize` `url` field in `MediaDataSource` struct
 | `customSeekHandler?`             | `object`  | `undefined`                  | Indicates a custom seek handler          |
 | `reuseRedirectedURL?`            | `boolean` | `false`                      | Reuse 301/302 redirected url for subsequence request like seek, reconnect, etc. |
 | `referrerPolicy?`                | `string`  | `no-referrer-when-downgrade` | Indicates the [Referrer Policy][] when using FetchStreamLoader |
+| `headers?`                       | `object`  | `undefined`                  | Indicates additional headers that will be added to request when using FetchStreamLoader |
 
 
 [Referrer Policy]: https://w3c.github.io/webappsec-referrer-policy/#referrer-policy

--- a/docs/api.md
+++ b/docs/api.md
@@ -88,7 +88,7 @@ In multipart mode, `duration` `filesize` `url` field in `MediaDataSource` struct
 | `customSeekHandler?`             | `object`  | `undefined`                  | Indicates a custom seek handler          |
 | `reuseRedirectedURL?`            | `boolean` | `false`                      | Reuse 301/302 redirected url for subsequence request like seek, reconnect, etc. |
 | `referrerPolicy?`                | `string`  | `no-referrer-when-downgrade` | Indicates the [Referrer Policy][] when using FetchStreamLoader |
-| `headers?`                       | `object`  | `undefined`                  | Indicates additional headers that will be added to request when using FetchStreamLoader |
+| `headers?`                       | `object`  | `undefined`                  | Indicates additional headers that will be added to request |
 
 
 [Referrer Policy]: https://w3c.github.io/webappsec-referrer-policy/#referrer-policy

--- a/src/config.js
+++ b/src/config.js
@@ -45,6 +45,7 @@ export const defaultConfig = {
     reuseRedirectedURL: false,
     // referrerPolicy: leave as unspecified
 
+    headers: undefined,
     customLoader: undefined
 };
 

--- a/src/io/fetch-stream-loader.js
+++ b/src/io/fetch-stream-loader.js
@@ -94,6 +94,13 @@ class FetchStreamLoader extends BaseLoader {
             referrerPolicy: 'no-referrer-when-downgrade'
         };
 
+        // add additional headers
+        if (typeof this._config.headers === 'object') {
+            for (let key in this._config.headers) {
+                headers.append(key, this._config.headers[key]);
+            }
+        }
+
         // cors is enabled by default
         if (dataSource.cors === false) {
             // no-cors means 'disregard cors policy', which can only be used in ServiceWorker

--- a/src/io/xhr-moz-chunked-loader.js
+++ b/src/io/xhr-moz-chunked-loader.js
@@ -101,6 +101,17 @@ class MozChunkedLoader extends BaseLoader {
             }
         }
 
+        // add additional headers
+        if (typeof this._config.headers === 'object') {
+            let headers = this._config.headers;
+
+            for (let key in headers) {
+                if (headers.hasOwnProperty(key)) {
+                    xhr.setRequestHeader(key, headers[key]);
+                }
+            }
+        }
+
         this._status = LoaderStatus.kConnecting;
         xhr.send();
     }

--- a/src/io/xhr-msstream-loader.js
+++ b/src/io/xhr-msstream-loader.js
@@ -141,6 +141,17 @@ class MSStreamLoader extends BaseLoader {
             }
         }
 
+        // add additional headers
+        if (typeof this._config.headers === 'object') {
+            let headers = this._config.headers;
+
+            for (let key in headers) {
+                if (headers.hasOwnProperty(key)) {
+                    xhr.setRequestHeader(key, headers[key]);
+                }
+            }
+        }
+
         if (this._isReconnecting) {
             this._isReconnecting = false;
         } else {

--- a/src/io/xhr-range-loader.js
+++ b/src/io/xhr-range-loader.js
@@ -159,6 +159,17 @@ class RangeLoader extends BaseLoader {
             }
         }
 
+        // add additional headers
+        if (typeof this._config.headers === 'object') {
+            let headers = this._config.headers;
+
+            for (let key in headers) {
+                if (headers.hasOwnProperty(key)) {
+                    xhr.setRequestHeader(key, headers[key]);
+                }
+            }
+        }
+
         xhr.send();
     }
 


### PR DESCRIPTION
Hello! First of all, thanks for the awesome library!

This PR adds additional optional headers to `createPlayer` config for use in `FetchStreamLoader`.
For example, it is needed to specify `'Authorization' `Basic Auth header to allow fetch FLV stream from auth protected URL.

Example
```js
var flvPlayer = flvjs.createPlayer({
    isLive: true,
    type: 'flv',
    url: "https:/localhost/flv",
}, {
    enableWorker: false,
    deferLoadAfterSourceOpen:false,
    enableStashBuffer: false,

    // additional authorization header
    headers: {
        'Authorization': 'Basic ' + btoa(unescape(encodeURIComponent("admin:1111")))
    },
});
```

There is `withCredentials` property on `dataSource` but it won't work if you don't want auth popup to appear for the user on a page that contains player.  That's because allowing adding `'Authorization`' header manually would be beneficial.

Thank you!