### PR TITLE
修复seek时，进度条往前跳的问题

### DIFF
--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -454,10 +454,11 @@ class FLVDemuxer {
     _parseKeyframesIndex(keyframes) {
         let times = [];
         let filepositions = [];
+        let timestampBase = this._getRealTimestamp(0)
 
         // ignore first keyframe which is actually AVC Sequence Header (AVCDecoderConfigurationRecord)
         for (let i = 1; i < keyframes.times.length; i++) {
-            let time = this._getRealTimestamp(Math.floor(keyframes.times[i] * 1000));
+            let time = timestampBase + Math.floor(keyframes.times[i] * 1000)
             times.push(time);
             filepositions.push(keyframes.filepositions[i]);
         }


### PR DESCRIPTION
在使用segments时发现一个bug,就是keyframes里的times是加上了上一段的时间，但是flv.js里又加上了timestampBase导致点击进度条时，进度条会往后跳一段时间。