### PR TITLE
--bug=解决连麦混流场景下codec变化导致的视频/音频卡死

### DIFF
--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -56,6 +56,7 @@ class FLVDemuxer {
         this._onScriptDataArrived = null;
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
+        this._onFlushStashedSamples = null;
 
         this._dataOffset = probeData.dataOffset;
         this._firstParse = true;
@@ -128,6 +129,7 @@ class FLVDemuxer {
         this._onScriptDataArrived = null;
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
+        this._onFlushStashedSamples = null;
     }
 
     static probe(buffer) {
@@ -211,6 +213,14 @@ class FLVDemuxer {
 
     set onDataAvailable(callback) {
         this._onDataAvailable = callback;
+    }
+
+    get onFlushStashedSamples() {
+        return this._onFlushStashedSamples;
+    }
+
+    set onFlushStashedSamples(callback) {
+        this._onFlushStashedSamples = callback;
     }
 
     // timestamp base for output samples, must be in milliseconds
@@ -530,6 +540,8 @@ class FLVDemuxer {
 
             if (aacData.packetType === 0) {  // AAC sequence header (AudioSpecificConfig)
                 if (meta.config) {
+                    // flush stashed samples if AudioSpecificConfig is changed
+                    this._onFlushStashedSamples && this._onFlushStashedSamples();
                     Log.w(this.TAG, 'Found another AudioSpecificConfig!');
                 }
                 let misc = aacData.data;
@@ -894,6 +906,8 @@ class FLVDemuxer {
             meta.duration = this._duration;
         } else {
             if (typeof meta.avcc !== 'undefined') {
+                // flush stashed samples if AVCDecoderConfigurationRecord is changed
+                this._onFlushStashedSamples && this._onFlushStashedSamples();
                 Log.w(this.TAG, 'Found another AVCDecoderConfigurationRecord!');
             }
         }

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -56,7 +56,7 @@ class FLVDemuxer {
         this._onScriptDataArrived = null;
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
-        this._onFlushStashedSamples = null;
+        this._onSeek = null;
 
         this._dataOffset = probeData.dataOffset;
         this._firstParse = true;
@@ -129,7 +129,7 @@ class FLVDemuxer {
         this._onScriptDataArrived = null;
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
-        this._onFlushStashedSamples = null;
+        this._onSeek = null;
     }
 
     static probe(buffer) {
@@ -215,12 +215,12 @@ class FLVDemuxer {
         this._onDataAvailable = callback;
     }
 
-    get onFlushStashedSamples() {
-        return this._onFlushStashedSamples;
+    get seek() {
+        return this._onSeek;
     }
 
-    set onFlushStashedSamples(callback) {
-        this._onFlushStashedSamples = callback;
+    set seek(callback) {
+        this._onSeek = callback;
     }
 
     // timestamp base for output samples, must be in milliseconds
@@ -541,7 +541,7 @@ class FLVDemuxer {
             if (aacData.packetType === 0) {  // AAC sequence header (AudioSpecificConfig)
                 if (meta.config) {
                     // flush stashed samples if AudioSpecificConfig is changed
-                    this._onFlushStashedSamples && this._onFlushStashedSamples();
+                    this.seek && this.seek();
                     Log.w(this.TAG, 'Found another AudioSpecificConfig!');
                 }
                 let misc = aacData.data;
@@ -907,7 +907,7 @@ class FLVDemuxer {
         } else {
             if (typeof meta.avcc !== 'undefined') {
                 // flush stashed samples if AVCDecoderConfigurationRecord is changed
-                this._onFlushStashedSamples && this._onFlushStashedSamples();
+                this.seek && this.seek();
                 Log.w(this.TAG, 'Found another AVCDecoderConfigurationRecord!');
             }
         }

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -83,6 +83,7 @@ class MP4Remuxer {
     bindDataSource(producer) {
         producer.onDataAvailable = this.remux.bind(this);
         producer.onTrackMetadata = this._onTrackMetadataReceived.bind(this);
+        producer.onFlushStashedSamples = this.flushStashedSamples.bind(this);
         return this;
     }
 

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -83,7 +83,7 @@ class MP4Remuxer {
     bindDataSource(producer) {
         producer.onDataAvailable = this.remux.bind(this);
         producer.onTrackMetadata = this._onTrackMetadataReceived.bind(this);
-        producer.onFlushStashedSamples = this.flushStashedSamples.bind(this);
+        producer.seek = this.seek.bind(this);
         return this;
     }
 


### PR DESCRIPTION
解决连麦混流场景下codec变化导致的视频/音频卡死 https://github.com/bilibili/flv.js/issues/355#issue-346089113