### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/io/xhr-range-loader.js
+++ b/src/io/xhr-range-loader.js
@@ -241,7 +241,7 @@ class RangeLoader extends BaseLoader {
                 }
             }
 
-            // calculate currrent request range's contentLength
+            // calculate current request range's contentLength
             if (this._range.to === -1) {
                 this._contentLength = this._totalLength - this._range.from;
             } else {  // to !== -1

--- a/src/remux/mp4-generator.js
+++ b/src/remux/mp4-generator.js
@@ -284,7 +284,7 @@ class MP4 {
         return MP4.box(MP4.types.hdlr, data);
     }
 
-    // Media infomation box
+    // Media information box
     static minf(meta) {
         let xmhd = null;
         if (meta.type === 'audio') {
@@ -295,7 +295,7 @@ class MP4 {
         return MP4.box(MP4.types.minf, xmhd, MP4.dinf(), MP4.stbl(meta));
     }
 
-    // Data infomation box
+    // Data information box
     static dinf() {
         let result = MP4.box(MP4.types.dinf,
             MP4.box(MP4.types.dref, MP4.constants.DREF)

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -80,7 +80,7 @@ function detect() {
         browser.webkit = true;
     }
 
-    // MSIE. IE11 has 'rv' identifer
+    // MSIE. IE11 has 'rv' identifier
     if (browser.rv || browser.iemobile) {
         if (browser.rv) {
             delete browser.rv;


### PR DESCRIPTION
There are small typos in:
- src/io/xhr-range-loader.js
- src/remux/mp4-generator.js
- src/utils/browser.js

Fixes:
- Should read `information` rather than `infomation`.
- Should read `identifier` rather than `identifer`.
- Should read `current` rather than `currrent`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md