### PR TITLE
Remove redundant polyfill.install()

### DIFF
--- a/src/utils/polyfill.js
+++ b/src/utils/polyfill.js
@@ -53,6 +53,4 @@ class Polyfill {
 
 }
 
-Polyfill.install();
-
 export default Polyfill;


### PR DESCRIPTION
polyfill.install() already used in flv.js, but there is a redundant polyfill.insatll() in polyfill.js. so remove it.