### PR TITLE
parseChunks方法中tagType解析优化

### DIFF
--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -306,7 +306,8 @@ class FLVDemuxer {
                 break;
             }
 
-            let tagType = v.getUint8(0);
+            //v[0] = Reversed<<6|Filter<<5|TagType
+            let tagType = v.getUint8(0)& 0x1f;
             let dataSize = v.getUint32(0, !le) & 0x00FFFFFF;
 
             if (offset + 11 + dataSize + 4 > chunk.byteLength) {


### PR DESCRIPTION
TagType由3个部分组成，如果不严格识别，可能会有一定的兼容问题