### PR TITLE
fix bug that when choose audio but can't solve it

### DIFF
--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -485,10 +485,11 @@ class FLVDemuxer {
         let soundSpec = v.getUint8(0);
 
         let soundFormat = soundSpec >>> 4;
-        if (soundFormat !== 2 && soundFormat !== 10) {  // MP3 or AAC
-            this._onError(DemuxErrors.CODEC_UNSUPPORTED, 'Flv: Unsupported audio codec idx: ' + soundFormat);
-            return;
-        }
+        // if not support this kind of sound ,then discard it but not throw exception
+        // if (soundFormat !== 2 && soundFormat !== 10) {  // MP3 or AAC
+        //     this._onError(DemuxErrors.CODEC_UNSUPPORTED, 'Flv: Unsupported audio codec idx: ' + soundFormat);
+        //     return;
+        // }
 
         let soundRate = 0;
         let soundRateIndex = (soundSpec & 12) >>> 2;
@@ -620,6 +621,9 @@ class FLVDemuxer {
             let mp3Sample = {unit: data, length: data.byteLength, dts: dts, pts: dts};
             track.samples.push(mp3Sample);
             track.length += data.length;
+        } else {
+            // set _hasAudio && discard audio
+            this._hasAudio = false;
         }
     }
 


### PR DESCRIPTION
个人理解，音频格式不能解析的情况下，如果不报错，而是不播放音频，这样可以兼容更多的场景。现实中我们也确实遇到了这样的情况，由于接入视频特别多，格式不统一，我们想有音频的尽可能播放下，而前端确很难识别哪些有音频，哪些没有